### PR TITLE
remove capital EPSG #27

### DIFF
--- a/R/add_gps_to_rayshader.R
+++ b/R/add_gps_to_rayshader.R
@@ -37,7 +37,7 @@ add_gps_to_rayshader <- function(raster_input, lat, long, alt, zscale, line_widt
 
   if (clamp_to_ground | ground_shadow) {
 
-    sp_gps <- sp::SpatialPoints(cbind(long, lat), proj4string = sp::CRS('+init=EPSG:4326'))
+    sp_gps <- sp::SpatialPoints(cbind(long, lat), proj4string = sp::CRS('+init=epsg:4326'))
 
     sp_gps <- sp::spTransform(sp_gps, sp::CRS(as.character(raster::crs(raster_input))))
 


### PR DESCRIPTION
Make "epsg" lower case in initialization string. 

(Alternatively could use "+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0" and avoid EPSG lookup). 

# Current behaviour

https://github.com/neilcharles/geoviz/issues/27

On Linux: 

```
 sp::CRS('+init=EPSG:4326')
Error in sp::CRS("+init=EPSG:4326") : no arguments in initialization list
```

On windows: 

```
sp::CRS('+init=EPSG:4326')
CRS arguments:
 +init=EPSG:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0 
```